### PR TITLE
Vault - Support default TTLs

### DIFF
--- a/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
+++ b/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
@@ -27,6 +27,7 @@ object VaultProviderConfig {
   val VAULT_CLIENT_PEM: String = "vault.client.pem"
   val VAULT_PEM: String = "vault.pem"
   val VAULT_ENGINE_VERSION = "vault.engine.version"
+  val VAULT_SECRET_TTL_DEFAULT: String = "vault.secret.ttl.default"
   val AUTH_METHOD: String = "vault.auth.method"
 
   val VAULT_TRUSTSTORE_LOC: String =
@@ -136,6 +137,13 @@ object VaultProviderConfig {
       2,
       Importance.HIGH,
       "KV Secrets Engine version of the Vault server instance. Defaults to 2"
+    )
+    .define(
+      VAULT_SECRET_TTL_DEFAULT,
+      Type.INT,
+      0,
+      Importance.MEDIUM,
+      "Default TTL for secrets returned from Vault. Defaults to 0 to not break existing configurations. Work around for the lack of `lease_duration` values returned from the Vault KV2 engine: https://github.com/hashicorp/vault/issues/6274"
     )
     // auth mode
     .define(

--- a/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
+++ b/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
@@ -46,6 +46,7 @@ case class VaultSettings(
     pem: String,
     clientPem: String,
     engineVersion: Int = 2,
+    secretTtlDefault: Int = 0,
     appRole: Option[AppRole],
     awsIam: Option[AwsIam],
     gcp: Option[Gcp],
@@ -72,6 +73,7 @@ object VaultSettings extends StrictLogging {
     val pem = config.getString(VaultProviderConfig.VAULT_PEM)
     val clientPem = config.getString(VaultProviderConfig.VAULT_CLIENT_PEM)
     val engineVersion = config.getInt(VaultProviderConfig.VAULT_ENGINE_VERSION)
+    val secretTtlDefault = config.getInt(VaultProviderConfig.VAULT_SECRET_TTL_DEFAULT)
 
     val authMode = VaultAuthMethod.withNameOpt(
       config.getString(VaultProviderConfig.AUTH_METHOD).toUpperCase
@@ -121,6 +123,7 @@ object VaultSettings extends StrictLogging {
       pem = pem,
       clientPem = clientPem,
       engineVersion = engineVersion,
+      secretTtlDefault = secretTtlDefault,
       appRole = appRole,
       awsIam = awsIam,
       gcp = gcp,

--- a/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
+++ b/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
@@ -133,8 +133,13 @@ class VaultSecretProvider() extends ConfigProvider with VaultHelper {
           )
         }
 
-        val ttl = Option(vaultClient.get.logical().read(path).getLeaseDuration) match {
-          case Some(duration) => Some(now.plusSeconds(duration))
+        val ttl = Option(response.getLeaseDuration) match {
+          case Some(duration) =>
+            if (duration != 0) {
+              Some(now.plusSeconds(duration))
+            } else {
+              Some(now.plusSeconds(settings.secretTtlDefault))
+            }
           case None => None
         }
 


### PR DESCRIPTION
Vault's KV2 engine does not return the `lease_duration` TTL value
that is provided by the original KV1 engine. When this value is 0
or missing it effectively disables the caching support of the
`VaultSecretProvider`.

This commit adds support for configuring an optional default TTL to apply
when the `lease_duration` value is 0.

To maintain backwards compatibility the default value remains 0.

Fixes https://github.com/lensesio/secret-provider/issues/4

Ref: https://github.com/hashicorp/vault/issues/6274