### PR TITLE
Recompute TTL values on each `get`

### DIFF
--- a/src/main/scala/io/lenses/connect/secrets/package.scala
+++ b/src/main/scala/io/lenses/connect/secrets/package.scala
@@ -145,7 +145,7 @@ package object connect extends StrictLogging {
   //calculate the min expiry for secrets and return the configData and expiry
   def getSecretsAndExpiry(
       secrets: Map[String, (String, Option[OffsetDateTime])]
-  ): (Option[OffsetDateTime], ConfigData) = {
+  ): (Option[OffsetDateTime], Map[String, String]) = {
     var expiryList = mutable.ListBuffer.empty[OffsetDateTime]
 
     val data = secrets
@@ -154,15 +154,12 @@ package object connect extends StrictLogging {
           expiry.foreach(e => expiryList.append(e))
           (key, value)
       })
-      .asJava
 
     if (expiryList.isEmpty) {
-      (None, new ConfigData(data))
+      (None, data)
     } else {
       val minExpiry = expiryList.min
-      val ttl = minExpiry.toInstant.toEpochMilli - OffsetDateTime.now.toInstant
-        .toEpochMilli
-      (Some(minExpiry), new ConfigData(data, ttl))
+      (Some(minExpiry), data)
     }
   }
 


### PR DESCRIPTION
TTL values must be recomputed on each `get` action instead
of being fixed to a constant value for the lifetime of the cached object.

Prior to this change, the constant TTL value `X` would cause kafka-connect
to continually reschedule connector restarts `X` milliseconds in the future,
effectively ensuring that the connector never actually restarts.

With this change, the reschedule actions have a timestamp that shrinks until
the TTL is reached.

Before (note contant restart time of ~30 mins):
```
2021-12-03 20:19:65,634 INFO   ||  Scheduling a restart of connector debezium_infra in 1799900 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
2021-12-03 20:18:25,143 INFO   ||  Scheduling a restart of connector debezium_infra in 1799900 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
```

After (note restart time decreases ~40 seconds and the log messages are ~40 seconds apart):
```
2021-12-03 21:09:24,228 INFO   ||  Scheduling a restart of connector debezium_infra in 2063263 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
2021-12-03 21:08:45,858 INFO   ||  Scheduling a restart of connector debezium_infra in 2101945 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
```